### PR TITLE
Correcting KeyError to AttributeError in __getattr__

### DIFF
--- a/perlmodule.c
+++ b/perlmodule.c
@@ -281,10 +281,10 @@ PerlObj_getattr(PerlObj_object *self, char *name) {
                 FREETMPS;
                 LEAVE;
             }
-            if (! retval) { /* give up and raise a KeyError */
+            if (! retval) { /* give up and raise a AttributeError */
                 char attribute_error[strlen(name) + 21];
                 sprintf(attribute_error, "attribute %s not found", name);
-                PyErr_SetString(PyExc_KeyError, attribute_error);
+                PyErr_SetString(PyExc_AttributeError, attribute_error);
             }
         }
         return retval;

--- a/t/23getattr.t
+++ b/t/23getattr.t
@@ -41,7 +41,7 @@ def test_attrs(foo):
 def test_noattrs(bar):
     try:
         perl.warn(bar.test)
-    except KeyError:
+    except AttributeError:
         return 1
     return 0
 


### PR DESCRIPTION
Hi,

To be conform to Python doc and standard, `__getattr__` has to raise an `AttributeError` if attribute is not there and not a `KeyError`. Example of test in Python 2.7:

``` python
>>> class Foo: pass
>>> Foo().test
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: Foo instance has no attribute 'test'
```

I have tested too in Python 2.5, the older Python distrib than Inline Python talks about in the documentation.

To give you a little context, I'm currently finishing to port Inline Python to Python 3. In P3, `__getattr__` MUST raise `AttributeError` if the attribute does not exist, otherwise our "getattr" implementation is not correct (i.e.  `hasattr` raises an exception, do not answer `False`) . Since it's even the standard in Python 2.x, I think it's interesting to correct it directly in Inline Python core, without a "if py_version == 3" condition.

In the next days, I will try to make more pull requests of things indirectly linked to the Python 3 port. My main goal is to make the more atomic commits that I can. I think it's a good practice and in addition easier for you to check.

Hope it helps!
