### PR TITLE
Prepare for Python3 compatibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -177,7 +177,7 @@ sub get_config_var {
     my $ref = shift;
     my $key = shift;
     my $exe = $ref->{path};
-    my $val = `$exe -c "import distutils.sysconfig; print distutils.sysconfig.get_config_var('$key')"`;
+    my $val = `$exe -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('$key'))"`;
     chomp $val;
     return $val;
 }

--- a/Python.xs
+++ b/Python.xs
@@ -491,7 +491,7 @@ py_has_attr(_inst, key)
 
   PPCODE:
 
-    Printf(("get_object_data\n"));
+    Printf(("get_object_data py_get_attr\n"));
 
     if (SvROK(_inst) && SvTYPE(SvRV(_inst))==SVt_PVMG) {
         inst = (PyObject*)SvIV(SvRV(_inst));
@@ -523,7 +523,7 @@ py_get_attr(_inst, key)
 
   PPCODE:
 
-    Printf(("get_object_data\n"));
+    Printf(("get_object_data py_has_attr\n"));
 
     if (SvROK(_inst) && SvTYPE(SvRV(_inst))==SVt_PVMG) {
         inst = (PyObject*)SvIV(SvRV(_inst));

--- a/perlmodule.c
+++ b/perlmodule.c
@@ -26,24 +26,24 @@ staticforward PyObject * special_perl_require(PyObject *, PyObject *);
  *         METHOD DECLARATIONS         *
  ***************************************/
 
-DL_EXPORT(PyObject) * newPerlPkg_object(PyObject *base, PyObject *pkg);
+PyObject * newPerlPkg_object(PyObject *base, PyObject *pkg);
 staticforward void       PerlPkg_dealloc(PerlPkg_object *self);
 staticforward PyObject * PerlPkg_repr(PerlPkg_object *self, PyObject *args);
 staticforward PyObject * PerlPkg_getattr(PerlPkg_object *self, char *name);
 
-DL_EXPORT(PyObject *) newPerlObj_object(SV *obj, PyObject *pkg);
+PyObject * newPerlObj_object(SV *obj, PyObject *pkg);
 staticforward void       PerlObj_dealloc(PerlObj_object *self);
 staticforward PyObject * PerlObj_repr(PerlObj_object *self, PyObject *args);
 staticforward PyObject * PerlObj_getattr(PerlObj_object *self, char *name);
 staticforward PyObject * PerlObj_mp_subscript(PerlObj_object *self, PyObject *key);
 
-DL_EXPORT(PyObject *) newPerlSub_object(PyObject *base,
+PyObject * newPerlSub_object(PyObject *base,
 					PyObject *pkg,
 					SV *cv);
-DL_EXPORT(PyObject *) newPerlMethod_object(PyObject *base,
+PyObject * newPerlMethod_object(PyObject *base,
 					   PyObject *pkg,
 					   SV *obj);
-DL_EXPORT(PyObject *) newPerlCfun_object(PyObject* (*cfun)(PyObject *self, 
+PyObject * newPerlCfun_object(PyObject* (*cfun)(PyObject *self,
 							   PyObject *args));
 staticforward void       PerlSub_dealloc(PerlSub_object *self);
 staticforward PyObject * PerlSub_call(PerlSub_object *self, PyObject *args, PyObject *kw);
@@ -149,8 +149,13 @@ PerlPkg_getattr(PerlPkg_object *self, char *name) {
     }
 }
 
+static PyObject * module_dir(PerlPkg_object *self, PyObject *args) {
+	return get_perl_pkg_subs(self->full);
+}
+
 static struct PyMethodDef PerlPkg_methods[] = {
-    {NULL, NULL} /* sentinel */
+	{"__dir__", (PyCFunction)module_dir, METH_NOARGS, NULL},
+    {NULL} /* sentinel */
 };
 
 /* doc string */
@@ -159,9 +164,8 @@ static char PerlPkg_type__doc__[] =
 ;
 
 /* type definition */
-DL_EXPORT(PyTypeObject) PerlPkg_type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                            /*ob_size*/
+PyTypeObject PerlPkg_type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
     "_perl_pkg",                  /*tp_name*/
     sizeof(PerlPkg_object),       /*tp_basicsize*/
     0,                            /*tp_itemsize*/
@@ -178,10 +182,18 @@ DL_EXPORT(PyTypeObject) PerlPkg_type = {
     (hashfunc)0,                  /*tp_hash*/
     (ternaryfunc)0,               /*tp_call*/
     (reprfunc)PerlPkg_repr,       /*tp_str*/
-
-    /* Space for future expansion */
-    0L,0L,0L,0L,
+    0,                         /* tp_getattro */
+    0,                         /* tp_setattro */
+    0,                         /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,        /* tp_flags */
     PerlPkg_type__doc__, /* Documentation string */
+    (traverseproc)0,           /* tp_traverse */
+    (inquiry)0,                /* tp_clear */
+    0,                         /* tp_richcompare */
+    0,                         /* tp_weaklistoffset */
+    0,                         /* tp_iter */
+    0,                         /* tp_iternext */
+    PerlPkg_methods,           /* tp_methods */
 };
 
 /* methods of _perl_obj */
@@ -295,7 +307,8 @@ static PyObject*
 PerlObj_mp_subscript(PerlObj_object *self, PyObject *key) {
     /* check if the object supports the __getitem__ protocol */
     PyObject *item = NULL;
-    char * const name = PyString_AsString(PyObject_Str(key));
+    PyObject *key_str = PyObject_Str(key);  /* new reference */
+    char * const name = PyString_AsString(key_str);
     SV * const obj = (SV*)SvRV(self->obj);
     HV * const pkg = SvSTASH(obj);
     GV* const gv = Perl_gv_fetchmethod_autoload(aTHX_ pkg, "__getitem__", FALSE);
@@ -336,8 +349,9 @@ PerlObj_mp_subscript(PerlObj_object *self, PyObject *key) {
         }
     }
     else {
-        PyErr_Format(PyExc_TypeError, "'%.200s' object is unsubscriptable", self->ob_type->tp_name);
+        PyErr_Format(PyExc_TypeError, "'%.200s' object is unsubscriptable", Py_TYPE(self)->tp_name);
     }
+    Py_DECREF(key_str);
     return item;
 }
 
@@ -385,8 +399,13 @@ PerlObj_compare(PerlObj_object *o1, PerlObj_object *o2) {
     return 1;
 }
 
+static PyObject * object_dir(PerlObj_object *self, PyObject *args) {
+	return get_perl_pkg_subs(self->pkg);
+}
+
 static struct PyMethodDef PerlObj_methods[] = {
-    {NULL, NULL} /* sentinel */
+	{"__dir__", (PyCFunction)object_dir, METH_NOARGS, NULL},
+    {NULL} /* sentinel */
 };
 
 /* doc string */
@@ -401,9 +420,8 @@ PyMappingMethods mp_methods = {
 };
 
 /* type definition */
-DL_EXPORT(PyTypeObject) PerlObj_type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                            /*ob_size*/
+PyTypeObject PerlObj_type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
     "_perl_obj",                  /*tp_name*/
     sizeof(PerlObj_object),       /*tp_basicsize*/
     0,                            /*tp_itemsize*/
@@ -424,6 +442,13 @@ DL_EXPORT(PyTypeObject) PerlObj_type = {
     /* Space for future expansion */
     0L,0L,0L,0L,
     PerlObj_type__doc__, /* Documentation string */
+    (traverseproc)0,           /* tp_traverse */
+    (inquiry)0,                /* tp_clear */
+    0,                          /* unused */
+    0,                         /* tp_weaklistoffset */
+    0,                         /* tp_iter */
+    0,                         /* tp_iternext */
+    PerlObj_methods,           /* tp_methods */
 };
 
 /* methods of _perl_sub */
@@ -695,9 +720,8 @@ static char PerlSub_type__doc__[] =
 ;
 
 /* type definition */
-DL_EXPORT(PyTypeObject) PerlSub_type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                            /*ob_size*/
+PyTypeObject PerlSub_type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
     "_perl_sub",                  /*tp_name*/
     sizeof(PerlSub_object),       /*tp_basicsize*/
     0,                            /*tp_itemsize*/
@@ -839,9 +863,8 @@ create_perl()
 }
 #endif
 
-DL_EXPORT(void)
-initperl(void)
-{
+void
+initperl(void){
     PyObject *m, *d, *p;
     PyObject *dummy1 = PyString_FromString(""), 
              *dummy2 = PyString_FromString("main");

--- a/perlmodule.h
+++ b/perlmodule.h
@@ -33,11 +33,20 @@ typedef struct {
     PyObject* (*cfun)(PyObject *self, PyObject *args); /* a regular Python function */
 } PerlSub_object;
 
-extern DL_IMPORT(PyTypeObject) PerlPkg_type, PerlObj_type, PerlSub_type;
+extern PyTypeObject PerlPkg_type, PerlObj_type, PerlSub_type;
 
-#define PerlPkgObject_Check(v) ((v)->ob_type == &PerlPkg_type)
-#define PerlObjObject_Check(v) ((v)->ob_type == &PerlObj_type)
-#define PerlSubObject_Check(v) ((v)->ob_type == &PerlSub_type)
+#ifndef PyVarObject_HEAD_INIT  /* Python 2.5 does not define this*/
+    #define PyVarObject_HEAD_INIT(type, size) \
+        PyObject_HEAD_INIT(type) size,
+#endif
+
+#ifndef Py_TYPE /* Python 2.5 does not define this*/
+#define Py_TYPE(ob) 			(((PyObject*)(ob))->ob_type)
+#endif
+
+#define PerlPkgObject_Check(v) (Py_TYPE(v) == &PerlPkg_type)
+#define PerlObjObject_Check(v) (Py_TYPE(v) == &PerlObj_type)
+#define PerlSubObject_Check(v) (Py_TYPE(v) == &PerlSub_type)
 
 #define PKG_EQ(obj,pkg) (strcmp(PyString_AsString((obj)->full), (pkg))==0)
 
@@ -46,15 +55,15 @@ extern DL_IMPORT(PyTypeObject) PerlPkg_type, PerlObj_type, PerlSub_type;
  ***************************************/
 
 /* methods of _perl_pkg */
-extern DL_IMPORT(PyObject *) newPerlPkg_object(PyObject *, PyObject *);
+extern PyObject * newPerlPkg_object(PyObject *, PyObject *);
 
 /* methods of _perl_obj */
-extern DL_IMPORT(PyObject *) newPerlObj_object(SV *, PyObject *);
+extern PyObject * newPerlObj_object(SV *, PyObject *);
 
 /* methods of _perl_sub */
-extern DL_IMPORT(PyObject *) newPerlSub_object(PyObject *, PyObject *, SV *);
-extern DL_IMPORT(PyObject *) newPerlMethod_object(PyObject*,PyObject*,SV*);
-extern DL_IMPORT(PyObject *) newPerlCfun_object(PyObject* (*)(PyObject *,
+extern PyObject * newPerlSub_object(PyObject *, PyObject *, SV *);
+extern PyObject * newPerlMethod_object(PyObject*,PyObject*,SV*);
+extern PyObject * newPerlCfun_object(PyObject* (*)(PyObject *,
 							      PyObject *));
 
 #ifdef __cplusplus

--- a/t/01testpl.t
+++ b/t/01testpl.t
@@ -9,18 +9,18 @@ def check_for_sub(sub):
     try: 
         f = getattr(perl,sub)
         if type(f).__name__ == "_perl_sub": 
-            print "Sub %s exists!" % sub
-	    return 1
+            print("Sub %s exists!" % sub)
+            return 1
         else:
-            print "%s is not a sub!" % sub
+            print("%s is not a sub!" % sub)
             return 0
     except AttributeError:
-        print "Sub %s not found!" % sub
+        print("Sub %s not found!" % sub)
         return 0
 
 def get_sub(sub):
     if check_for_sub(sub): return getattr(perl,sub)
-    else: raise AttributeError, "No such sub"
+    else: raise AttributeError("No such sub")
 
 END
 
@@ -33,17 +33,17 @@ use Inline::Python qw(py_eval);
 py_eval(<<END);
 perl.use("Data::Dumper")
 perl.f()
-print perl.Dumper({'neil': 0, 'laura': 1}), # suppress extra \n
+print(perl.Dumper({'neil': 0, 'laura': 1})), # suppress extra \n
 perl.ok(1)
-print perl.CORE
+print(perl.CORE)
 perl.ok(1)
-print dir(perl)
+print(dir(perl))
 perl.ok(1)
 t = get_sub('f')
 t.flags = t.G_EVAL | t.G_KEEPERR
 t()
 
-perl.py_eval("print 'Wow. Now that is weird'")
+perl.py_eval("print('Wow. Now that is weird')")
 perl.ok(1)
 
 END

--- a/t/02testpl.t
+++ b/t/02testpl.t
@@ -27,14 +27,14 @@ class A:
     def __init__(self):
         self.data = {}
     def foof(self):
-        print "Hello, back in Python..."
+        print("Hello, back in Python...")
 
 def gen(): return A()
 
 END
 
 ok(1);
-py_eval("print dir(perl)");
+py_eval("print(dir(perl))");
 ok(1);
 my $o = new A;
 ok(1);
@@ -44,7 +44,7 @@ print "It's gone now...\n";
 py_eval(<<END);
 o = perl.Fart.Fiddle.new()
 if o: perl.ok(1)
-print o
+print(o)
 o.foof({'neil': 1}, ['laura', 1], 12)
 perl.ok(1)
 perl.eval('print qq{Hello. This is Neil\\n}')

--- a/t/03parse.t
+++ b/t/03parse.t
@@ -15,7 +15,7 @@ perl.ok_is(1, 1) # Well, we got this far...
 perl.use("Data::Dumper")
 perl.use("Parse::RecDescent")
 perl.eval('print "Hello\n"')
-print perl.Data.Dumper.Dumper({'neil': 'happy', 'others': 'sad'})
+print(perl.Data.Dumper.Dumper({'neil': 'happy', 'others': 'sad'}))
 o = perl.Parse.RecDescent.new("Parse::RecDescent","dumb: 'd' 'u' 'm' 'b'")
 perl.ok_is(o.dumb("dumb"), 'b')
 perl.ok_is(o.dumb("dork"), None)

--- a/t/04func.t
+++ b/t/04func.t
@@ -6,18 +6,18 @@ BEGIN { plan tests => 3 }
 
 use Inline::Python qw(py_eval py_call_function);
 
-ok(py_eval("print 'Hello from Python!'"), undef);
+ok(py_eval("print('Hello from Python!')"), undef);
 
 py_eval(<<'END');
 
 class Foo:
 	def __init__(self):
-		print "Foo() created!"
+		print("Foo() created!")
 	def apple(self): 
-		print "Doing an apple!"
+		print("Doing an apple!")
 
 def funky(a):
-	print a
+	print(a)
 
 END
 

--- a/t/07nherit.t
+++ b/t/07nherit.t
@@ -5,19 +5,19 @@ use Inline Python => <<'END';
 
 class Daddy:
     def __init__(self):
-        print "Who's your daddy?"
+        print("Who's your daddy?")
         self.fish = []
     def push(self,dat):
-        print "Daddy.push(%s)" % dat
+        print("Daddy.push(%s)" % dat)
         return self.fish.append(dat)
     def pop(self):
-        print "Daddy.pop()"
+        print("Daddy.pop()")
         return self.fish.pop()
 
 class Mommy:
-    def __init__(self):
-        print "Who's your mommy?"
-        self.jello = "hello"
+    def __init__(self, s):
+        print("Who's your mommy?")
+        self.jello = s
     def add(self,data):
         self.jello = self.jello + data
         return self.jello
@@ -26,18 +26,18 @@ class Mommy:
         return self.jello
 
 class Foo(Daddy,Mommy):
-    def __init__(self):
-        print "new Foo object being created"
+    def __init__(self, s):
+        print("new Foo object being created")
         self.data = {}
         Daddy.__init__(self)
-        Mommy.__init__(self)
+        Mommy.__init__(self, s)
     def get_data(self): return self.data
     def set_data(self,dat): 
         self.data = dat
 
 END
 
-my $obj = new Foo;
+my $obj = new Foo("hello");
 ok(not keys %{$obj->get_data()});
 
 $obj->set_data({string => 'hello',

--- a/t/08ipyobj.t
+++ b/t/08ipyobj.t
@@ -12,18 +12,18 @@ py_eval <<END;
 
 class Foo:
     def __init__(self):
-        print "New foo being created!"
-	self.data = {}
+        print("New foo being created!")
+        self.data = {}
     def watchit(self):
-        print "Watching it, sir!"
-	print self.data
+        print("Watching it, sir!")
+        print(self.data)
     def put(self, key, value):
-	self.data[key] = value
+        self.data[key] = value
     def get(self, key):
-	try:
-	    return self.data[key]
-	except KeyError:
-	    return None
+        try:
+            return self.data[key]
+        except KeyError:
+            return None
 
 END
 

--- a/t/09bind.t
+++ b/t/09bind.t
@@ -12,18 +12,18 @@ py_eval <<END;
 
 class Foo:
     def __init__(self):
-        print "New foo being created!"
-	self.data = {}
+        print("New foo being created!")
+        self.data = {}
     def watchit(self):
-        print "Watching it, sir!"
-	print self.data
+        print("Watching it, sir!")
+        print(self.data)
     def put(self, key, value):
-	self.data[key] = value
+        self.data[key] = value
     def get(self, key):
-	try:
-	    return self.data[key]
-	except KeyError:
-	    return None
+        try:
+            return self.data[key]
+        except KeyError:
+            return None
 
 END
 

--- a/t/10pyeval.t
+++ b/t/10pyeval.t
@@ -7,7 +7,7 @@ py_eval(<<END);
 class Bar:
     def __init__(self): 
         self.data = {}
-        print "new Bar being created!"
+        print("new Bar being created!")
     def put(self, key, val): self.data[key] = val
     def get(self, key): 
         try: return self.data[key]

--- a/t/15anon.t
+++ b/t/15anon.t
@@ -14,6 +14,6 @@ def Foo():
     class Bar:
         def __init__(self): pass
         def method(self, lang):
-            print "Note: lang=%s" % lang
+            print("Note: lang=%s" % lang)
             return 42
     return Bar()

--- a/t/18newclass.t
+++ b/t/18newclass.t
@@ -5,19 +5,19 @@ use Inline Python => <<'END';
 
 class Daddy(object):
     def __init__(self):
-        print "Who's your daddy?"
+        print("Who's your daddy?")
         self.fish = []
     def push(self,dat):
-        print "Daddy.push(%s)" % dat
+        print("Daddy.push(%s)" % dat)
         return self.fish.append(dat)
     def pop(self):
-        print "Daddy.pop()"
+        print("Daddy.pop()")
         return self.fish.pop()
 
 class Mommy:
-    def __init__(self):
-        print "Who's your mommy?"
-        self.jello = "hello"
+    def __init__(self, s):
+        print("Who's your mommy?")
+        self.jello = s
     def add(self,data):
         self.jello = self.jello + data
         return self.jello
@@ -26,18 +26,18 @@ class Mommy:
         return self.jello
 
 class Foo(Daddy,Mommy):
-    def __init__(self):
-        print "new Foo object being created"
+    def __init__(self, s):
+        print("new Foo object being created")
         self.data = {}
         Daddy.__init__(self)
-        Mommy.__init__(self)
+        Mommy.__init__(self, s)
     def get_data(self): return self.data
     def set_data(self,dat): 
         self.data = dat
 
 END
 
-my $obj = new Foo;
+my $obj = new Foo("hello");
 print "object is: ", ref($obj), "\n";
 ok(not keys %{$obj->get_data()});
 

--- a/t/22int.t
+++ b/t/22int.t
@@ -1,5 +1,5 @@
 use Test;
-BEGIN { plan tests => 3 }
+BEGIN { plan tests => 4 }
 use Inline Config => DIRECTORY => './blib_test';
 use Inline::Python qw(py_call_function);
 use Inline Python => <<'END';
@@ -12,6 +12,7 @@ def test(i):
 
 END
 
+ok(py_call_function('__main__', 'get_int'), 10, 'int arrives as int');
 ok(py_call_function('__main__', 'test', 4), "<type 'int'>", 'int arrives as int');
 ok(py_call_function('__main__', 'test', '4'), "<type 'str'>", 'string that looks like a number arrives as string');
 ok(py_call_function('__main__', 'test', py_call_function('__main__', 'get_int')), "<type 'int'>", 'int from python to perl to python is still an int');

--- a/t/23getattr.t
+++ b/t/23getattr.t
@@ -32,11 +32,11 @@ use Inline::Python qw(py_eval py_call_function);
 
 py_eval(<<'END');
 
-def test_attrs(foo):
+def test_attrs(foo, s):
     perl.ok(hasattr(foo, 'test'))
     perl.ok(not hasattr(foo, 'foo'))
-    perl.ok(foo.test == 'Attrs test!')
-    perl.ok(foo.__getattr__('test') == 'Attrs test!')
+    perl.ok(foo.test == s)
+    perl.ok(foo.__getattr__('test') == s)
 
 def test_noattrs(bar):
     try:
@@ -47,5 +47,5 @@ def test_noattrs(bar):
 
 END
 
-ok(py_call_function("__main__", "test_attrs", Attrs->new), undef);
+ok(py_call_function("__main__", "test_attrs", Attrs->new, 'Attrs test!'), undef);
 ok(py_call_function("__main__", "test_noattrs", NoAttrs->new) == 1);

--- a/t/24getitem.t
+++ b/t/24getitem.t
@@ -32,9 +32,9 @@ use Inline::Python qw(py_eval py_call_function);
 
 py_eval(<<'END');
 
-def test_items(foo):
-    perl.ok(foo['test'] == 'Items test!')
-    perl.ok(foo['test'] == 'Items test!')
+def test_items(foo, s):
+    perl.ok(foo['test'] == s)
+    perl.ok(foo['test'] == s)
 
 def test_noitems(bar):
     try:
@@ -45,5 +45,5 @@ def test_noitems(bar):
 
 END
 
-ok(py_call_function("__main__", "test_items", Items->new), undef);
+ok(py_call_function("__main__", "test_items", Items->new, 'Items test!'), undef);
 ok(py_call_function("__main__", "test_noitems", NoItems->new) == 1);

--- a/t/27pyattrs.t
+++ b/t/27pyattrs.t
@@ -51,4 +51,4 @@ is($foo->{get_foo}->(), 'foo', 'Returned method works');
 
 my $killer = KillMe->new();
 ok(not(eval { $killer->{foo} }), 'survived KeyError in __getattr__');
-is($@, "exceptions.KeyError: 'foo' at line 19\n", 'Got the KeyError');
+like($@, qr/KeyError: 'foo' at line 19/, 'Got the KeyError');

--- a/t/28exception.t
+++ b/t/28exception.t
@@ -26,25 +26,25 @@ eval {
     error();
 };
 ok(1, 'Survived Python exception');
-is($@, "exceptions.Exception: Error! at line 3\n", 'Exception found');
+like($@, qr/Error! at line 3/, 'Exception found');
 
 eval {
     empty_error();
 };
-is($@, "exceptions.Exception:  at line 6\n", 'Exception found');
+like($@, qr/Exception:  at line 6/, 'Exception found');
 
 eval {
     name_error();
 };
-is($@, "exceptions.NameError: global name 'foo' is not defined at line 9\n", 'NameError found');
+like($@, qr/name 'foo' is not defined at line 9/, 'NameError found');
 
 my $foo = Foo->new;
 eval {
     $foo->error;
 };
-is($@, "exceptions.Exception: Error! at line 13\n", 'Exception found');
+like($@, qr/Exception: Error! at line 13/, 'Exception found');
 
 eval {
     thrower()->();
 };
-is($@, "exceptions.NameError: global name 'foo' is not defined at line 16\n", 'NameError found');
+like($@, qr/name 'foo' is not defined at line 16/, 'Exception found');

--- a/util.c
+++ b/util.c
@@ -32,7 +32,7 @@ int free_inline_py_obj(pTHX_ SV* obj, MAGIC *mg)
     if (mg && mg->mg_type == PERL_MAGIC_ext && Inline_Magic_Check(mg->mg_ptr)) {
         IV const iv = SvIV(obj);
         /*Printf(("free_inline_py_obj: %p, iv: %p, ob_prev: %p, ob_next: %p, refcnt: %i\n", obj, iv, ((PyObject *)iv)->_ob_prev, ((PyObject *)iv)->_ob_next, ((PyObject *)iv)->ob_refcnt)); */ /* _ob_prev and _ob_next are only available if Python is compiled with reference debugging enabled */
-        Printf(("free_inline_py_obj: %p, iv: %p, refcnt: %i\n", obj, iv, ((PyObject *)iv)->ob_refcnt));
+        Printf(("free_inline_py_obj: %p, iv: %p, refcnt: %i\n", obj, iv, (int)Py_REFCNT(iv)));
         Py_XDECREF((PyObject *)iv); /* just in case */
     }
     else {

--- a/util.h
+++ b/util.h
@@ -5,6 +5,11 @@
 extern "C" {
 #endif
 
+
+#ifndef Py_REFCNT /* Python 2.5 does not define this */
+	#define Py_REFCNT(ob)           (((PyObject*)(ob))->ob_refcnt)
+#endif
+
 /* Before Perl 5.6, this didn't exist */
 #ifndef SvPV_nolen
 #define SvPV_nolen(sv) SvPV(sv,PL_na)
@@ -37,10 +42,10 @@ typedef struct {
 #define Inline_Magic_Key(mg_ptr) (((_inline_magic*)mg_ptr)->key)
 #define Inline_Magic_Check(mg_ptr) (Inline_Magic_Key(mg_ptr)==INLINE_MAGIC_KEY)
 
-extern DL_IMPORT(PyObject *) get_perl_pkg_subs(PyObject *);
-extern DL_IMPORT(int)	     perl_pkg_exists(char *, char *);
-extern DL_IMPORT(PyObject *) perl_sub_exists(PyObject *, PyObject *);
-extern DL_IMPORT(int)        py_is_tuple(SV *arr);
+extern PyObject * get_perl_pkg_subs(PyObject *);
+extern int        perl_pkg_exists(char *, char *);
+extern PyObject * perl_sub_exists(PyObject *, PyObject *);
+extern int        py_is_tuple(SV *arr);
 
 extern MGVTBL inline_mg_vtbl;
 /* This is called when Perl deallocates a PerlObj object */


### PR DESCRIPTION
Hi,

In this commit, you'll find all the stuffs I had to do to be compliant at the same time with the C Python 3 API and the C Python 2 API, but without using a "#if PY_MAJOR_VERSION == 3" hack. This means:
- Add parenthesis to Python code (test and Makefile.PL)
- Change mixed space/tab in Python code with spaces only
- Remove DL_EXPORT/DL_IMPORT Macro (deprecated since Py2.3)
- Use Macro Py_TYPE, Py_REFCNT and PyVarObject_HEAD_INIT. Add "ifndef" since Python 2.5 does not recognize them.
- Add `__dir__` method to perl package and perl object (`dir()` is no more looking for  `__methods__` attribute in Py3)

In addition, few Py_DECREF/Py_XDECREF was missing.

Tested on Ubuntu 14.04 with Python 2.5.6, 2.6.9 and 2.7.6
