### PR TITLE
Python 3 support

### DIFF
--- a/Python.pod
+++ b/Python.pod
@@ -747,8 +747,20 @@ tested there. I strongly suspect it will require patching. Please send me
 patches.
 
 This version of Inline::Python has been tested with Python versions from 2.5 to
-2.7. It may work on older versions but will almost certainly not work with
-Python 3.
+2.7. It may work on older versions.
+This version has also been tested with version from 3.1 to 3.4.
+
+=head1 PORTING YOUR INLINE PYTHON CODE FROM 2 TO 3
+
+First of all, follow the Python guide from 2 to 3:
+https://docs.python.org/3/howto/pyporting.html
+
+For Perl integration:
+
+ - Non-utf8-flagged Perl strings will be Python bytes, utf8-flagged Perl strings will be Python string
+ - __cmp__ is no more supported in Python 3 and has been replaced by "rich comparison" (i.e. __eq__, __le__, etc.°. 
+Since booleans in Perl are integers, renaming __cmp__ to __eq__ is often enough while wrapping a Perl object in Python.
+ - perl.require, perl.use and perl.eval accept either bytes or strings.
 
 =head1 SOURCE REPOSITORY
 

--- a/README
+++ b/README
@@ -29,7 +29,7 @@ The almost-one-line version is:
 INSTALLATION:
 
 This module requires Inline.pm version 0.46 or higher to be installed. In 
-addition, you need Python 1.5.2 or greater installed. Python 2.0 or greater
+addition, you need Python 2.5 or greater installed. Python 2.6, Python 3.2 or greater
 is recommended.
 
 Python has to be configured with --enable-shared. Linux distribution packages

--- a/perlmodule.h
+++ b/perlmodule.h
@@ -48,7 +48,18 @@ extern PyTypeObject PerlPkg_type, PerlObj_type, PerlSub_type;
 #define PerlObjObject_Check(v) (Py_TYPE(v) == &PerlObj_type)
 #define PerlSubObject_Check(v) (Py_TYPE(v) == &PerlSub_type)
 
+#if PY_MAJOR_VERSION >= 3
+#define PKG_EQ(obj,pkg) (strcmp(PyBytes_AsString((obj)->full), (pkg))==0)
+#else
 #define PKG_EQ(obj,pkg) (strcmp(PyString_AsString((obj)->full), (pkg))==0)
+#endif
+
+/* Macro for returning Py_NotImplemented from a function */
+#ifndef Py_RETURN_NOTIMPLEMENTED /* Python 3.1 does not define this*/
+#define Py_RETURN_NOTIMPLEMENTED \
+    return Py_INCREF(Py_NotImplemented), Py_NotImplemented
+#endif
+
 
 /***************************************
  *         METHOD DECLARATIONS         *

--- a/t/05JAxH.t
+++ b/t/05JAxH.t
@@ -5,7 +5,11 @@ BEGIN {
 }
 
 use Inline Python => <<'END';
-def JAxH(x): return "Just Another %s Hacker" % x
+import sys
+if sys.version_info[0] < 3:
+    def JAxH(x): return "Just Another %s Hacker" % x
+else:
+    def JAxH(x): return "Just Another %s Hacker" % x.decode('utf-8')
 END
 
 print "not " unless JAxH('Inline') eq "Just Another Inline Hacker";

--- a/t/06dict.t
+++ b/t/06dict.t
@@ -8,19 +8,35 @@ use Inline Config => DIRECTORY => './blib_test';
 use Inline Python => <<'END';
 # coding=utf-8
 
+def PyVersion(): import sys; return sys.version_info[0]
+
 class Foo:
     def __init__(self):
-        print "new Foo object being created"
+        print("new Foo object being created")
         self.data = {}
     def get_data(self): return self.data
     def set_data(self,dat):
         self.data = dat
-        self.data[u'ü'] = u'ü'
+        if PyVersion() == 3:
+            self.data['ü'] = 'ü'
+        else:
+            # u'ü' is not a valid syntax in Py3.1
+            s = '\xc3\xbc'.decode('utf-8') 
+            self.data[s] = s
 
 def get_dict():
-    return {u'föö': 'bar'}
+    if PyVersion() == 3:
+        return {'föö': 'bar'}
+    else:
+        # u'föö' is not a valid syntax in Py3.1
+        return {'f\xc3\xb6\xc3\xb6'.decode('utf-8'): 'bar'}
+
 def access_dict(test_dict):
-    return test_dict[u'föö']
+    if PyVersion() == 3:
+        return test_dict['föö']
+    else:
+        # u'föö' is not a valid syntax in Py3.1
+        return test_dict['f\xc3\xb6\xc3\xb6'.decode('utf-8')]
 END
 
 my $obj = new Foo;

--- a/t/22int.t
+++ b/t/22int.t
@@ -9,10 +9,19 @@ def get_int():
 
 def test(i):
     return type(i)
+    
+def PyVersion(): import sys; return sys.version_info[0]
 
 END
 
 ok(py_call_function('__main__', 'get_int'), 10, 'int arrives as int');
-ok(py_call_function('__main__', 'test', 4), "<type 'int'>", 'int arrives as int');
-ok(py_call_function('__main__', 'test', '4'), "<type 'str'>", 'string that looks like a number arrives as string');
-ok(py_call_function('__main__', 'test', py_call_function('__main__', 'get_int')), "<type 'int'>", 'int from python to perl to python is still an int');
+if (PyVersion() == 3) {
+	ok(py_call_function('__main__', 'test', 4), "<class 'int'>", 'int arrives as int');
+	ok(py_call_function('__main__', 'test', '4'), "<class 'bytes'>", 'string that looks like a number arrives as string');
+	ok(py_call_function('__main__', 'test', py_call_function('__main__', 'get_int')), "<class 'int'>", 'int from python to perl to python is still an int');
+}
+else {
+	ok(py_call_function('__main__', 'test', 4), "<type 'int'>", 'int arrives as int');
+	ok(py_call_function('__main__', 'test', '4'), "<type 'str'>", 'string that looks like a number arrives as string');
+	ok(py_call_function('__main__', 'test', py_call_function('__main__', 'get_int')), "<type 'int'>", 'int from python to perl to python is still an int');
+}

--- a/t/26undef.t
+++ b/t/26undef.t
@@ -7,10 +7,13 @@ use Inline Python => <<'END';
 def debug(x):
     return str(x)
 
+def PyVersion(): import sys; return sys.version_info[0]
+
 END
 
 my @a = ('foo' , 'bar', 'baz');
 delete $a[1];
 
 ok(debug(undef) eq 'None');
-ok(debug(\@a) eq "['foo', None, 'baz']");
+ok(debug(\@a) eq "['foo', None, 'baz']") if PyVersion() == 2;
+ok(debug(\@a) eq "[b'foo', None, b'baz']") if PyVersion() == 3;

--- a/t/cmp.t
+++ b/t/cmp.t
@@ -10,6 +10,11 @@ sub __cmp__ {
     return $$self cmp $$other;
 }
 
+sub __eq__ {
+    my ($self, $other) = @_;
+    return $$self cmp $$other;	
+}
+
 package FailComparer;
 
 sub new {
@@ -18,6 +23,11 @@ sub new {
 }
 
 sub __cmp__ {
+    my ($self, $other) = @_;
+    return 'foo';
+}
+
+sub __eq__ {
     my ($self, $other) = @_;
     return 'foo';
 }
@@ -51,4 +61,4 @@ py_call_function("__main__", "test", map { Comparer->new($_) } qw(foo foo bar));
 eval {
     py_call_function("__main__", "test_fail", map { FailComparer->new($_) } qw(foo foo));
 };
-like($@, qr/__cmp__ must return an integer!/);
+like($@, qr/__ must return an integer!/);

--- a/util.c
+++ b/util.c
@@ -43,7 +43,11 @@ int free_inline_py_obj(pTHX_ SV* obj, MAGIC *mg)
 }
 
 PyObject * get_perl_pkg_subs(PyObject *package) {
+#if PY_MAJOR_VERSION >= 3
+    char * const pkg = PyBytes_AsString(package);
+#else
     char * const pkg = PyString_AsString(package);
+#endif
     PyObject * const retval = PyList_New(0);
     HV * const hash = perl_get_hv(pkg, 0);
     int const len = hv_iterinit(hash);
@@ -56,7 +60,11 @@ PyObject * get_perl_pkg_subs(PyObject *package) {
         char * const test = (char*)malloc((strlen(pkg) + strlen(key) + 1)*sizeof(char));
         sprintf(test,"%s%s",pkg,key);
         if (perl_get_cv(test,0)) {
+#if PY_MAJOR_VERSION >= 3
+            PyList_Append(retval, PyUnicode_FromString(key));
+#else
             PyList_Append(retval, PyString_FromString(key));
+#endif
         }
         free(test);
     }
@@ -84,8 +92,13 @@ int perl_pkg_exists(char *base, char *pkg) {
 }
 
 PyObject * perl_sub_exists(PyObject *package, PyObject *usub) {
+#if PY_MAJOR_VERSION >= 3
+    char * const pkg = PyBytes_AsString(package);
+    char * const sub = PyBytes_AsString(usub);
+#else
     char * const pkg = PyString_AsString(package);
     char * const sub = PyString_AsString(usub);
+#endif
     PyObject * retval = Py_None;
 
     char * const qsub = (char*)malloc((strlen(pkg) + strlen(sub) + 1)*sizeof(char));

--- a/util.h
+++ b/util.h
@@ -5,6 +5,17 @@
 extern "C" {
 #endif
 
+/* Python 2 => 3 rename */
+#if PY_MAJOR_VERSION >= 3
+#define PyInt_FromLong PyLong_FromLong
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_Check PyLong_Check
+
+#define PyClass_Check PyType_Check
+
+#define staticforward static
+#define statichere static
+#endif
 
 #ifndef Py_REFCNT /* Python 2.5 does not define this */
 	#define Py_REFCNT(ob)           (((PyObject*)(ob))->ob_refcnt)


### PR DESCRIPTION
Hi again!

Here is the Python 3 support. I have tested it on Ubuntu 14.04 with Python 2.5.6, 2.6.9, 2.7.6, 3.1.5, 3.2.5, 3.3.5 and 3.4.0.
On my Ubuntu, I just have to do:

``` bash
export INLINE_PYTHON_EXECUTABLE=/usr/bin/python3
```

before calling `perl Makefile.PL` and all goes fine.

Remarks:
- I tried to update the POD with some useful information but I'm not a POD expert... I think you should check my english and see if it's really useful... Moreover, it might be a good idea to talk about the "INLINE_PYTHON_EXECUTABLE". I don't  know...
- Supporting 2.5 and 3.1 in tests at the same time is a nightmare, since:
  - b'...' syntax is not allowed in Python 2.5 _at all_ (not compiling)
  - u'...' syntax is not allowed in Python 3.1 _at all_ (not compiling)

It's why you can see in tests something like:

``` python
        # u'föö' is not a valid syntax in Py3.1
        return {'f\xc3\xb6\xc3\xb6'.decode('utf-8'): 'bar'}
```
- `exec` has changed between 2 and 3, it's why the test 19 seems a little strange (http://stackoverflow.com/questions/6561482)

If something seems strange or inappropriate, let me know! I will do more commits in this pull request if needed.
Hope it helps!

Laurent
