### PR TITLE
Remove obsolete vars pragma

### DIFF
--- a/Python.pm
+++ b/Python.pm
@@ -4,7 +4,7 @@ use Carp;
 require Inline;
 require DynaLoader;
 require Exporter;
-use vars qw(@ISA $VERSION @EXPORT_OK);
+our ($VERSION, @ISA, @EXPORT_OK);
 @ISA = qw(Inline DynaLoader Exporter);
 $VERSION = '0.48';
 @EXPORT_OK = qw(py_eval


### PR DESCRIPTION
This is a small fix disposing of an [obsolete](http://perldoc.perl.org/vars.html#DESCRIPTION) `vars` pragma.

This PR is part of my [CPANPR Challenge](http://neilb.org/2014/11/29/pr-challenge-2015.html). I wish it was more substantial, but I'd need to brush up my XS skills first :)

Cheers,
Sergey