### PR TITLE
Fix dictionary with `unicode` keys memory leak

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use Data::Dumper;
 use Config;
 use Cwd qw(abs_path);
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.64;
 use Getopt::Long;
 
 GetOptions(
@@ -97,12 +97,16 @@ WriteMakefile(
               LICENSE => 'perl',
 	      VERSION_FROM => 'Python.pm',
 	      PREREQ_PM => {
-                            Inline         => 0.46,
+                            'Inline'       => 0.46,
                             'Digest::MD5'  => 2.50,
                             'Data::Dumper' => 0,
-                            'Test::More'   => 0,
-                            Test           => 0,
-			   },
+			  },
+        TEST_REQUIRES => {
+                            'Test'                => 0,
+                            'Test::More'          => 0,
+                            'Test::Deep'          => 0,
+                            'Proc::ProcessTable'  => '0.53',
+        },
 	      OBJECT => 'Python.o py2pl.o perlmodule.o util.o',
 	      META_MERGE => {
 			    "meta-spec" => { version => 2 },

--- a/py2pl.c
+++ b/py2pl.c
@@ -206,6 +206,8 @@ SV *Py2Pl(PyObject * const obj) {
                 SvUTF8_on(utf8_key);
 
                 hv_store_ent(retval, utf8_key, sv_val, 0);
+
+                sv_2mortal(utf8_key);
                 Py_DECREF(utf8_string);
             }
             else {

--- a/t/35dictunicodememleak.t
+++ b/t/35dictunicodememleak.t
@@ -1,0 +1,44 @@
+#
+# Returning Python dictionaries with 'unicode' keys might lead to memory leaks.
+# This test creates a memory leak situation and verifies that RSS usage is normal.
+#
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Test::Deep;
+
+use Proc::ProcessTable;
+
+use Inline Config => DIRECTORY => './blib_test';
+use Inline Python => <<'END';
+
+def python_dict_with_unicode_key():
+    return {
+        u'abcdefghijklmno': 1,
+        u'pqrstuvwxyz': 2,
+    }
+
+END
+
+sub get_rss_memory {
+    my $pt = Proc::ProcessTable->new;
+    my %info = map { $_->pid => $_ } @{ $pt->table };
+    return $info{ $$ }->rss;
+}
+
+my $iterations = 3_000_000;
+
+my $rss_before_iterations = get_rss_memory();
+# print STDERR "RSS (KB) before python_dict_with_unicode_key(): $rss_before_iterations\n";
+
+my $dict;
+for (my $x = 0; $x < $iterations; ++$x) {
+    $dict = python_dict_with_unicode_key();
+}
+my $rss_after_iterations = get_rss_memory();
+# print STDERR "RSS (KB) after python_dict_with_unicode_key(): $rss_after_iterations\n";
+
+ok( $rss_after_iterations - $rss_before_iterations < 100 * 1024, "RSS takes up less than 100 MB" );
+cmp_deeply( $dict, { 'abcdefghijklmno' => 1, 'pqrstuvwxyz' => 2 } );


### PR DESCRIPTION
Fixes #12.

f131c62 is the actual fix, more of a wild intuitive guess than a thorough investigation. 			4e48791 tests the fix by fetching a Python dictionary for 5m times and having a look at the RSS memory usage afterwards.