### PR TITLE
Multiply RSS usage on OS X to bytes

### DIFF
--- a/t/35dictunicodememleak.t
+++ b/t/35dictunicodememleak.t
@@ -25,20 +25,25 @@ END
 sub get_rss_memory {
     my $pt = Proc::ProcessTable->new;
     my %info = map { $_->pid => $_ } @{ $pt->table };
-    return $info{ $$ }->rss;
+    my $rss = $info{ $$ }->rss;
+    if ($^O eq 'darwin') {
+    	# RSS is reported in kilobytes instead of bytes on OS X
+    	$rss *= 1024;
+    }
+    return $rss;
 }
 
 my $iterations = 3_000_000;
 
 my $rss_before_iterations = get_rss_memory();
-# print STDERR "RSS (KB) before python_dict_with_unicode_key(): $rss_before_iterations\n";
+# print STDERR "RSS before python_dict_with_unicode_key(): $rss_before_iterations\n";
 
 my $dict;
 for (my $x = 0; $x < $iterations; ++$x) {
     $dict = python_dict_with_unicode_key();
 }
 my $rss_after_iterations = get_rss_memory();
-# print STDERR "RSS (KB) after python_dict_with_unicode_key(): $rss_after_iterations\n";
+# print STDERR "RSS after python_dict_with_unicode_key(): $rss_after_iterations\n";
 
-ok( $rss_after_iterations - $rss_before_iterations < 100 * 1024, "RSS takes up less than 100 MB" );
+ok( $rss_after_iterations - $rss_before_iterations < 100 * 1024 * 1024, "RSS takes up less than 100 MB" );
 Test::Deep::cmp_deeply( $dict, { 'abcdefghijklmno' => 1, 'pqrstuvwxyz' => 2 } );


### PR DESCRIPTION
Hi Neil (Neil, right?),

In 4e4879154c329790e965ba85adbcd8e89666b4be, `Proc::ProcessTable` is reporting RSS usage in bytes on Linux and kilobytes on OS X, so the memory usage was being tested incorrectly. This commit fixes that.