### PR TITLE
Require Parse::RecDescent (needed by t/03parse.t)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -105,6 +105,7 @@ WriteMakefile(
                             'Test'                => 0,
                             'Test::More'          => 0,
                             'Test::Deep'          => 0,
+                            'Parse::RecDescent'   => '1.967013',
                             'Proc::ProcessTable'  => '0.53',
         },
 	      OBJECT => 'Python.o py2pl.o perlmodule.o util.o',


### PR DESCRIPTION
Add missing test dependency.