### PR TITLE
Get rid of "Insecure dependency in open while running with -T switch" 

### DIFF
--- a/Python.pm
+++ b/Python.pm
@@ -190,6 +190,7 @@ sub build {
 
     $o->mkpath("$o->{API}{install_lib}/auto/$o->{API}{modpname}");
 
+    ($o->{API}{location}) = $o->{API}{location} =~ /(.*)/ if $o->{CONFIG}{UNTAINT};
     open PYDAT, "> $o->{API}{location}" or
       croak "Inline::Python couldn't write parse information!";
     print PYDAT $namespace;
@@ -207,6 +208,7 @@ sub load {
     return if $o->{ILSM}{loaded};
 
     # Load the code
+    ($o->{API}{location}) = $o->{API}{location} =~ /(.*)/ if $o->{CONFIG}{UNTAINT};
     open PYDAT, $o->{API}{location} or 
       croak "Couldn't open parse info!";
     my $pydat = join '', <PYDAT>;


### PR DESCRIPTION
Untaint $o->{API}{location} when it run under taint mode.