### PR TITLE
Add MIN_PERL_VERSION for kwalitee

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -96,6 +96,7 @@ WriteMakefile(
               AUTHOR => 'Neil Watkiss <NEILW@cpan.org>',
               LICENSE => 'perl',
 	      VERSION_FROM => 'Python.pm',
+		  MIN_PERL_VERSION => '5.6.0',
 	      PREREQ_PM => {
                             'Inline'       => 0.46,
                             'Digest::MD5'  => 2.50,


### PR DESCRIPTION
This updates Makefile.PL to specify 5.6.0 as the minimum perl version as this is required for the use of "our" in Python.pm.

Although t/20unicode.t needs 5.8.0, it gracefully handles older perls and is not necessary for runtime.

This PR is provided as part of the [CPAN PR Challenge](http://cpan-prc.org/).  Thanks for taking part.