### PR TITLE
Note in POD about SIGINT handling

### DIFF
--- a/Python.pod
+++ b/Python.pod
@@ -201,6 +201,16 @@ constants C<$Inline::Python::Boolean::true> and
 C<$Inline::Python::Boolean::false> if it is important that the value is
 of type Boolean in Python.
 
+=head1 Signal Handlers
+
+Python overrides C<$SIG{INT}> such that SIGINT signals are then ignored by
+the rest of the Perl code unless the handler is explicitly reset
+afterwards. eg:
+
+   use Inline Python => 'print "python called"';
+   $SIG{INT} = 'DEFAULT'; # Without this the loop is uninterruptible
+   while (1) { }
+
 =head1 Using Perl inside Python (inside Perl)
 
 This section doesn't talk at all about C<Inline::Python>. It's about how


### PR DESCRIPTION
See [RT 117122](https://rt.cpan.org/Public/Bug/Display.html?id=117122).

A note explaining this behaviour and the trivial workaround is now in Python.pod.

This PR is provided as part of the [CPAN PR Challenge](http://cpan-prc.org/). Thanks for participating.