### PR TITLE
Pass ASCII strings as <class 'str'> in Python 3

### DIFF
--- a/py2pl.c
+++ b/py2pl.c
@@ -427,7 +427,7 @@ PyObject *Pl2Py(SV * const obj) {
         Printf(("string = "));
         Printf(("%s\n", str));
 #if PY_MAJOR_VERSION >= 3
-        if (SvUTF8(obj))
+        if (SvUTF8(obj) || is_ascii_string((U8*) str, len))
             o = PyUnicode_DecodeUTF8(str, len, "replace");
         else
             o = PyBytes_FromStringAndSize(str, len);
@@ -501,7 +501,7 @@ PyObject *Pl2Py(SV * const obj) {
             char * const key_str = SvPV(key, len);
             PyObject *py_key;
 #if PY_MAJOR_VERSION >= 3
-            if (SvUTF8(key))
+            if (SvUTF8(key) || is_ascii_string((U8*) key_str, len))
                 py_key = PyUnicode_DecodeUTF8(key_str, len, "replace");
             else
                 py_key = PyBytes_FromStringAndSize(key_str, len);

--- a/t/05JAxH.t
+++ b/t/05JAxH.t
@@ -5,11 +5,7 @@ BEGIN {
 }
 
 use Inline Python => <<'END';
-import sys
-if sys.version_info[0] < 3:
-    def JAxH(x): return "Just Another %s Hacker" % x
-else:
-    def JAxH(x): return "Just Another %s Hacker" % x.decode('utf-8')
+def JAxH(x): return "Just Another %s Hacker" % x
 END
 
 print "not " unless JAxH('Inline') eq "Just Another Inline Hacker";

--- a/t/19testref.t
+++ b/t/19testref.t
@@ -317,8 +317,8 @@ TEST_FUNC
 
 my $test_func_p3 = <<'TEST_FUNC';
 def test_func(context):
-    foo = context[b'foo']
-    context[b'bar'] = foo.new()
+    foo = context['foo']
+    context['bar'] = foo.new()
     return foo
 TEST_FUNC
 

--- a/t/22int.t
+++ b/t/22int.t
@@ -17,7 +17,7 @@ END
 ok(py_call_function('__main__', 'get_int'), 10, 'int arrives as int');
 if (PyVersion() == 3) {
 	ok(py_call_function('__main__', 'test', 4), "<class 'int'>", 'int arrives as int');
-	ok(py_call_function('__main__', 'test', '4'), "<class 'bytes'>", 'string that looks like a number arrives as string');
+	ok(py_call_function('__main__', 'test', '4'), "<class 'str'>", 'string that looks like a number arrives as string');
 	ok(py_call_function('__main__', 'test', py_call_function('__main__', 'get_int')), "<class 'int'>", 'int from python to perl to python is still an int');
 }
 else {

--- a/t/26undef.t
+++ b/t/26undef.t
@@ -6,14 +6,10 @@ use Inline Config => DIRECTORY => './blib_test';
 use Inline Python => <<'END';
 def debug(x):
     return str(x)
-
-def PyVersion(): import sys; return sys.version_info[0]
-
 END
 
 my @a = ('foo' , 'bar', 'baz');
 delete $a[1];
 
 ok(debug(undef) eq 'None');
-ok(debug(\@a) eq "['foo', None, 'baz']") if PyVersion() == 2;
-ok(debug(\@a) eq "[b'foo', None, b'baz']") if PyVersion() == 3;
+ok(debug(\@a) eq "['foo', None, 'baz']");

--- a/t/36utfstring.t
+++ b/t/36utfstring.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 2;
+
+use Inline Config => DIRECTORY => './blib_test';
+use Inline Python => <<'END';
+def add_x(string):
+    return 'x' + string
+END
+
+my $str_utf8  = 'abć';
+my $str_ascii = 'abc';
+
+is add_x($str_utf8),  "x$str_utf8",  'string op on unicode string';
+is add_x($str_ascii), "x$str_ascii", 'string op on ascii string';


### PR DESCRIPTION
ASCII strings are not flagged as utf8 by default, however since ASCII-only strings are encoded in exactly the same way before and after utf8::upgrade, it's safe to decode them. This allows most regular Perl strings to be properly passed as str to Python 3 (non-ASCII strings will have the utf8 flag on under the utf8 pragma, others will still be passed as bytes).

This fixes #27 .