### PR TITLE
Fix build on Windows with recent Python versions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -171,7 +171,8 @@ sub special_get_libpath {
     my $val = `$ref->{path} -c "import distutils.command.build_ext; d=distutils.core.Distribution(); b=distutils.command.build_ext.build_ext(d);b.finalize_options();print(b.library_dirs[0])" 2>&1`;
     chomp $val;
     $ref->{libpath} = $val;
-    $ref->{libpython} = basename((glob("$val/libpython*.a"))[0]);
+    my @python_libs=sort {$b cmp $a} (glob("$val/libpython*.a"),glob("$val/python*.lib"));
+    $ref->{libpython} = basename($python_libs[0]) if(@python_libs);
     return $val;
 }
 
@@ -232,6 +233,18 @@ sub get_config_var {
     return $val;
 }
 
+sub get_default_python_lib_index {
+  my $r_found_libs=shift;
+
+  # Avoid limited API libraries (ABI), which are versionned with 1 digit only
+  # (cf https://docs.python.org/3/c-api/stable.html)
+  for my $i (0..$#{$r_found_libs}) {
+    return ($i+1) if($r_found_libs->[$i] =~ /python\d\.?\d[^\/\\]+$/i);
+  }
+  
+  return 1;
+}
+
 sub query_options {
     my $ref = shift;
 
@@ -256,7 +269,8 @@ END
 	Here are the libraries I know about:
 END
     my @libs = show_python_libs($ref);
-    my $lib = prompt("Which? Or enter another.", '1');
+    my $defaultLibIndex = $^O eq 'MSWin32' ? get_default_python_lib_index(\@libs) : 1;
+    my $lib = prompt("Which? Or enter another.", $defaultLibIndex);
     $lib = $libs[$lib-1] if $lib =~ /^\d+$/;
     $lib =~ s|\\|/|g;
     $ref->{libpath} = substr($lib, 0, rindex($lib, '/'));

--- a/t/00init.t
+++ b/t/00init.t
@@ -5,6 +5,7 @@ BEGIN {
 use File::Path;
 
 rmtree("./blib_test");
+sleep(1) if($^O eq 'MSWin32'); # workaround for dubious behavior on Windows...
 mkdir("./blib_test", 0777) or print "not ok 1\n" && exit;
 
 print "ok 1\n";

--- a/t/35dictunicodememleak.t
+++ b/t/35dictunicodememleak.t
@@ -9,6 +9,7 @@ use warnings;
 use Test::More;
 eval { require Proc::ProcessTable; require Test::Deep; };
 plan skip_all => "Test requires Proc::ProcessTable and Test::Deep: $@" if $@;
+plan skip_all => "Test requires an operating system providing rss info to Proc::ProcessTable module" if($^O eq 'MSWin32');
 plan tests => 2;
 
 use Inline Config => DIRECTORY => './blib_test';


### PR DESCRIPTION
- support new Python library name format on Windows during
auto-detection (libpython*.a --> python*.lib)
- fix error "fileparse(): need a valid pathname at Makefile.PL line
174." introduced by commit bedc5820 when Python libraries are not found
automatically (this error prevented accessing the interactive mode to
try to workaround the problem manually !)
- avoid selecting the limited Python API library (ABI) by default on
Windows (fix missing symbols error)
- naive workaround for weird race condition on some Windows versions
happening between "rmtree" and "mkdir" calls in 00init test (when
re-running the tests)
- skip test 35dictunicodememleak on Windows as the "rss" field is not
provided by the Proc::ProcessTable module on Windows (on Windows, test
should be rewritten using Win32::API module and calling
getProcessMemoryInfo from psapi.dll instead)