### PR TITLE
Improve compatibility with strict(er) C99 compilers

### DIFF
--- a/perlmodule.h
+++ b/perlmodule.h
@@ -76,6 +76,8 @@ extern PyObject * newPerlSub_object(PyObject *, PyObject *, SV *);
 extern PyObject * newPerlMethod_object(PyObject*, PyObject*, SV*);
 extern PyObject * newPerlCfun_object(PyObject* (*)(PyObject *, PyObject *));
 
+extern void initperl(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add missing declaration of initperl to avoid an implicit function declaration in Python.xs.  Implicit function declarations were removed from C in 1999, and future compilers are likely to reject them by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
