### PR TITLE
Fix compiler warnings

### DIFF
--- a/perlmodule.c
+++ b/perlmodule.c
@@ -516,7 +516,7 @@ PerlObj_richcompare(PerlObj_object *o1, PerlObj_object *o2, int op) {
 
     GV* const gv = Perl_gv_fetchmethod_autoload(aTHX_ pkg, method_name, FALSE);
     if (gv && isGV(gv)) {
-        int retval;
+        int retval = 1;
         dSP;
 
         ENTER;
@@ -567,7 +567,7 @@ PerlObj_compare(PerlObj_object *o1, PerlObj_object *o2) {
     HV * const pkg = SvSTASH(obj);
     GV* const gv = Perl_gv_fetchmethod_autoload(aTHX_ pkg, "__cmp__", FALSE);
     if (gv && isGV(gv)) {
-        int retval;
+        int retval = 1;
         dSP;
 
         ENTER;
@@ -963,10 +963,6 @@ PerlSub_setattr(PerlSub_object *self, char *name, PyObject *v) {
         return -1;  /* failure */
     }
 }
-
-static struct PyMethodDef PerlSub_methods[] = {
-    {NULL, NULL} /* sentinel */
-};
 
 /* doc string */
 static char PerlSub_type__doc__[] = 

--- a/py2pl.c
+++ b/py2pl.c
@@ -568,7 +568,7 @@ croak_python_exception() {
         if (ex_traceback) {
             PyObject * const tb_lineno = PyObject_GetAttrString(ex_traceback, "tb_lineno");
 
-            croak("%s: %s at line %i\n", ((PyTypeObject *)ex_type)->tp_name, c_ex_message, PyInt_AsLong(tb_lineno));
+            croak("%s: %s at line %li\n", ((PyTypeObject *)ex_type)->tp_name, c_ex_message, PyInt_AsLong(tb_lineno));
 
             Py_DECREF(tb_lineno);
         }


### PR DESCRIPTION
~~~
py2pl.c: In function ‘croak_python_exception’:
py2pl.c:571:36: warning: format ‘%i’ expects argument of type ‘int’, but argument 4 has type ‘long int’ [-Wformat=]
  571 |             croak("%s: %s at line %i\n", ((PyTypeObject *)ex_type)->tp_name, c_ex_message, PyInt_AsLong(tb_lineno));
      |                                   ~^
      |                                    |
      |                                    int
      |                                   %li

perlmodule.c: In function ‘PerlObj_richcompare’:
perlmodule.c:549:11: warning: ‘retval’ may be used uninitialized [-Wmaybe-uninitialized]
  549 |         if(retval == 0) {Py_RETURN_TRUE;}
      |           ^
perlmodule.c:519:13: note: ‘retval’ was declared here
  519 |         int retval;
      |             ^~~~~~

perlmodule.c:967:27: warning: ‘PerlSub_methods’ defined but not used [-Wunused-variable]
  967 | static struct PyMethodDef PerlSub_methods[] = {
      |                           ^~~~~~~~~~~~~~~
~~~
